### PR TITLE
Fix pyopencl compile error if the include path contains space

### DIFF
--- a/kernelFuncBuilder.py
+++ b/kernelFuncBuilder.py
@@ -38,7 +38,7 @@ class KernelFuncBuilder:
         sep = os.linesep
         tabSpace = '  '
 
-        strDSInclude = '#include "%s"'%(self.strDSFileName) + sep
+        strDSInclude = '#include "%s"'%(os.path.join(self.strOutputFolder, self.strDSFileName)) + sep
         with open(self.strFilePath, 'w') as fKF:
             fKF.write(strDSInclude)
             fKF.write(sep)


### PR DESCRIPTION
Some platform doesn't support space for the include path
